### PR TITLE
to improve setup time, download from local sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ admin.conf
 
 rpi-client-v1.*.*.img.xz
 rpi-server-v1.*.*.img.xz
+
+k3s
+helm
+rackn-catalog.json

--- a/scripts/local_base.sh
+++ b/scripts/local_base.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright RackN 2020
+# License APLv2
+# Version 1.0
+
+# Caches files to local DRP to speed start_me process
+
+# Local Base is much faster for setups where Wifi is not reliable
+echo "Get latest isos"
+drpcli bootenvs uploadiso sledgehammer
+
+echo "Get latest install components"
+
+curl -fsL repo.rackn.io --compressed -o rackn-catalog.json
+SOURCE=$(cat rackn-catalog.json | jq -r '.sections.catalog_items["drp-tip"].Source')
+echo "uploading dr-provision zip from $SOURCE"
+drpcli files upload $SOURCE as bootstrap/dr-provision.zip
+rm rackn-catalog.json
+
+echo "uploading install.sh from get.rebar.digital/tip"
+drpcli files upload https://get.rebar.digital/tip as bootstrap/install.sh
+
+echo "Upload files into local DRP"
+for f in k3s helm; do
+  if [[ -f "$f" ]]; then
+    echo "Found $f, uploading"
+    drpcli files upload $f as "$f/$f"
+  else
+    echo "No $f, skipping"
+  fi
+done
+
+echo "done"

--- a/scripts/local_base.sh
+++ b/scripts/local_base.sh
@@ -26,7 +26,8 @@ for f in k3s helm; do
     echo "Found $f, uploading"
     drpcli files upload $f as "$f/$f"
   else
-    echo "No $f, skipping"
+    drpcli files upload http://10.3.14.1:8091/files/$f/$f as "$f/$f" || true
+    echo "No $f, trying to download from Edge Lab on 10.3.14.1"
   fi
 done
 

--- a/scripts/start_me.sh
+++ b/scripts/start_me.sh
@@ -64,7 +64,7 @@ echo "Check for local install files before using Wifi"
 if curl --output /dev/null --silent --head --fail "$LOCALBASE/files/bootstrap/install.sh"; then
   echo "Using Local Install Files from $LOCALBASE"
   curl -fsSL $LOCALBASE/files/bootstrap/dr-provision.zip -o dr-provision.zip
-  curl -fsSL $LOCALBASE/files/bootstrap/install.sh | bash -s -- --start-runner --systemd --startup --bootstrap --zip-file=dr-provision.zip install
+  curl -fsSL $LOCALBASE/files/bootstrap/install.sh | bash -s -- --start-runner --systemd --startup --bootstrap --drp-version=tip --zip-file=dr-provision.zip install
   echo "Upload ISOs from $LOCALBASE"
   for iso in sledgehammer-9b5276ac5826520829aa73c149fe672fe2363656.arm64.tar sledgehammer-9b5276ac5826520829aa73c149fe672fe2363656.rpi4.tar sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar; do
     drpcli isos upload $LOCALBASE/isos/$iso to $iso

--- a/scripts/start_me.sh
+++ b/scripts/start_me.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright RackN 2020
 # License APLv2
-# Version 1.2
+# Version 1.3
 
 SSID=$1
 PASSWORD=$2
@@ -58,8 +58,30 @@ if ! which jq ; then
   ln -s /usr/local/bin/drpcli /usr/local/bin/jq
 fi
 
-echo "Getting and Installing latest DRP..."
-curl -fsSL get.rebar.digital/tip | bash -s -- --start-runner --systemd --startup --bootstrap --drp-version=tip install
+# Local Base is much faster for setups where Wifi is not reliable
+LOCALBASE="http://10.3.14.2:8091"
+echo "Check for local install files before using Wifi"
+if curl --output /dev/null --silent --head --fail "$LOCALBASE/files/bootstrap/install.sh"; then
+  echo "Using Local Install Files from $LOCALBASE"
+  curl -fsSL $LOCALBASE/files/bootstrap/dr-provision.zip -o dr-provision.zip
+  curl -fsSL $LOCALBASE/files/bootstrap/install.sh | bash -s -- --start-runner --systemd --startup --bootstrap --zip-file=dr-provision.zip install
+  echo "Upload ISOs from $LOCALBASE"
+  for iso in sledgehammer-9b5276ac5826520829aa73c149fe672fe2363656.arm64.tar sledgehammer-9b5276ac5826520829aa73c149fe672fe2363656.rpi4.tar sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar; do
+    drpcli isos upload $LOCALBASE/isos/$iso to $iso
+  done
+  echo "Upload Extras from $LOCALBASE"
+  for file in k3s helm; do
+    if [[ "$(curl -fsSLk -o /dev/null -w %{http_code} $LOCALBASE/files/$file/$file 2>/dev/null)" == "200" ]]; then
+      echo "uploading $file"
+      drpcli files upload $LOCALBASE/files/$file/$file to $file/$file
+    else
+      echo "did not find $file, skipping"
+    fi
+  done
+else
+  echo "Downloading and Installing latest DRP..."
+  curl -fsSL get.rebar.digital/tip | bash -s -- --start-runner --systemd --startup --bootstrap --drp-version=tip install
+fi
 
 echo "Getting Edge-lab content"
 drpcli catalog item install edge-lab --version=tip >/dev/null


### PR DESCRIPTION
Adds an option to the start_me script that speeds local testing/setup by using local resources first.

Includes a script to upload the needed resources into a local DRP server as the webserver.  This is very handy because the ISOs are correctly populated using DRP bootenvs.

Note: for now, the sledgehammer versions are hardcoded